### PR TITLE
ダラス公演のセットリストの修正

### DIFF
--- a/src/data/events.ts
+++ b/src/data/events.ts
@@ -10548,7 +10548,7 @@ export const EVENTS: Event[] = [
         70, // FAKE IT
         155, // FLASH
         MC,
-        24, // ポリリズム
+        22, // チョコレイト・ディスコ
       ],
       [
         110, // Magic of Love(Album-mix)


### PR DESCRIPTION
ダラス公演の時のリストを修正させて下さい。この時にはチョコレート・ディスコが演奏されました。現場にいたので間違いはないと思います。